### PR TITLE
RK-9362 - Don't request token for on-prem deployments

### DIFF
--- a/controllers/rookout_controller.go
+++ b/controllers/rookout_controller.go
@@ -117,6 +117,22 @@ func (r *RookoutReconciler) updateOperatorConfiguration(config rookoutv1alpha1.R
 		return
 	}
 
+	for _, matcher := range configuration.Spec.Matchers {
+		rookoutTokenFound := false
+
+		for _, envVar := range matcher.EnvVars {
+			if envVar.Name == RookoutTokenEnvVar {
+				rookoutTokenFound = true
+				break
+			}
+		}
+
+		if !rookoutTokenFound {
+			logrus.Error("Rookout token env var not found in all matchers")
+			return
+		}
+	}
+
 	configuration.isReady = true
 	logrus.Info("Operator configuration updated")
 }

--- a/controllers/rookout_controller.go
+++ b/controllers/rookout_controller.go
@@ -41,6 +41,7 @@ const (
 	DefaultSharedVolumeMountPath        = "/rookout"
 	RookoutEnvVarPreffix                = "ROOKOUT_"
 	RookoutTokenEnvVar                  = "ROOKOUT_TOKEN"
+	RookoutControllerHostEnvVar         = "ROOKOUT_CONTROLLER_HOST"
 )
 
 // !!!!!!!!!!!!!!!!!!!!
@@ -119,16 +120,24 @@ func (r *RookoutReconciler) updateOperatorConfiguration(config rookoutv1alpha1.R
 
 	for _, matcher := range configuration.Spec.Matchers {
 		rookoutTokenFound := false
+		onPremControllerFound := false
 
 		for _, envVar := range matcher.EnvVars {
 			if envVar.Name == RookoutTokenEnvVar {
 				rookoutTokenFound = true
+			}
+
+			if envVar.Name == RookoutControllerHostEnvVar {
+				onPremControllerFound = true
+			}
+
+			if onPremControllerFound && rookoutTokenFound {
 				break
 			}
 		}
 
-		if !rookoutTokenFound {
-			logrus.Error("Rookout token env var not found in all matchers")
+		if !rookoutTokenFound && !onPremControllerFound {
+			logrus.Errorf("%s env var required for SaaS deployment", RookoutTokenEnvVar)
 			return
 		}
 	}

--- a/controllers/rookout_controller.go
+++ b/controllers/rookout_controller.go
@@ -137,7 +137,7 @@ func (r *RookoutReconciler) updateOperatorConfiguration(config rookoutv1alpha1.R
 		}
 
 		if !rookoutTokenFound && !onPremControllerFound {
-			logrus.Errorf("%s env var required for SaaS deployment", RookoutTokenEnvVar)
+			logrus.Infof("Are you trying to connect to a deployed Rookout controller? if so, use %s and if you don't, use %s. See our docs at docs.rookout.com\"t", RookoutControllerHostEnvVar, RookoutTokenEnvVar)
 			return
 		}
 	}

--- a/controllers/rookout_controller.go
+++ b/controllers/rookout_controller.go
@@ -117,22 +117,6 @@ func (r *RookoutReconciler) updateOperatorConfiguration(config rookoutv1alpha1.R
 		return
 	}
 
-	for _, matcher := range configuration.Spec.Matchers {
-		rookoutTokenFound := false
-
-		for _, envVar := range matcher.EnvVars {
-			if envVar.Name == RookoutTokenEnvVar {
-				rookoutTokenFound = true
-				break
-			}
-		}
-
-		if !rookoutTokenFound {
-			logrus.Error("Rookout token env var not found in all matchers")
-			return
-		}
-	}
-
 	configuration.isReady = true
 	logrus.Info("Operator configuration updated")
 }


### PR DESCRIPTION
We don't need `ROOKOUT_TOKEN` for on-prem controllers