### PR TITLE
RK-9874 - Gilad/save deployments in as state

### DIFF
--- a/controllers/deployments_manager.go
+++ b/controllers/deployments_manager.go
@@ -34,5 +34,7 @@ func (d *DeploymentsManager) addPatchedDeployment(deployment apps.Deployment) {
 }
 
 func (d *DeploymentsManager) isDeploymentPatched(deployment apps.Deployment) bool {
-	return d.Deployments[deployment.UID].isPatched
+	mappedDeployment, exist := d.Deployments[deployment.UID]
+
+	return exist && mappedDeployment.isPatched
 }

--- a/controllers/deployments_manager.go
+++ b/controllers/deployments_manager.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// We are saving a state of all running deployments in the cluster
+type DeploymentsManager struct {
+	Deployments map[types.UID]*RunningDeployment
+}
+
+type RunningDeployment struct {
+	*apps.Deployment
+	isPatched bool
+}
+
+func NewDeploymentsManager() DeploymentsManager {
+	return DeploymentsManager{Deployments: make(map[types.UID]*RunningDeployment, 0)}
+}
+
+func (d *DeploymentsManager) addNonPatchedDeployment(deployment apps.Deployment) {
+	d.Deployments[deployment.UID] = &RunningDeployment{
+		Deployment: deployment.DeepCopy(),
+		isPatched:  false,
+	}
+}
+
+func (d *DeploymentsManager) addPatchedDeployment(deployment apps.Deployment) {
+	d.Deployments[deployment.UID] = &RunningDeployment{
+		Deployment: deployment.DeepCopy(),
+		isPatched:  true,
+	}
+}
+
+func (d *DeploymentsManager) isDeploymentPatched(deployment apps.Deployment) bool {
+	return d.Deployments[deployment.UID].isPatched
+}

--- a/controllers/matcher_utils.go
+++ b/controllers/matcher_utils.go
@@ -73,3 +73,12 @@ func getConfigStr(config string, defaultValue string) string {
 
 	return defaultValue
 }
+
+func removeElementWithSuffix(s []string, suffix string) []string {
+	for i, v := range s {
+		if strings.HasSuffix(v, suffix) {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
+}

--- a/controllers/matcher_utils.go
+++ b/controllers/matcher_utils.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/rookout/rookout-k8s-operator/api/v1alpha1"
 	"github.com/sirupsen/logrus"
-	v12 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func setRookoutEnvVars(env *[]v1.EnvVar, evnVars []v1.EnvVar) {
+func setRookoutEnvVars(env *[]core.EnvVar, evnVars []core.EnvVar) {
 	for _, envVar := range evnVars {
 		if !strings.HasPrefix(envVar.Name, RookoutEnvVarPreffix) {
 			logrus.Warnf("%s is not a valid env variable. Only vars with %s prefix allowed.", envVar.Name, RookoutEnvVarPreffix)
@@ -21,7 +21,7 @@ func setRookoutEnvVars(env *[]v1.EnvVar, evnVars []v1.EnvVar) {
 	}
 }
 
-func labelsMatch(matcher v1alpha1.Matcher, deployment v12.Deployment) bool {
+func labelsMatch(matcher v1alpha1.Matcher, deployment apps.Deployment) bool {
 	for expectedLabelName, expectedLabelValue := range matcher.Labels {
 		labelMatched := false
 
@@ -40,15 +40,15 @@ func labelsMatch(matcher v1alpha1.Matcher, deployment v12.Deployment) bool {
 	return true
 }
 
-func namespaceMatch(matcher v1alpha1.Matcher, deployment v12.Deployment) bool {
+func namespaceMatch(matcher v1alpha1.Matcher, deployment apps.Deployment) bool {
 	return matcher.Namespace == "" || strings.Contains(deployment.GetNamespace(), matcher.Namespace)
 }
 
-func deploymentMatch(matcher v1alpha1.Matcher, deployment v12.Deployment) bool {
+func deploymentMatch(matcher v1alpha1.Matcher, deployment apps.Deployment) bool {
 	return matcher.Deployment == "" || strings.Contains(deployment.Name, matcher.Deployment)
 }
 
-func containerMatch(matcher v1alpha1.Matcher, container v1.Container) bool {
+func containerMatch(matcher v1alpha1.Matcher, container core.Container) bool {
 	return matcher.Container == "" || strings.Contains(container.Name, matcher.Container)
 }
 

--- a/controllers/rookout_controller.go
+++ b/controllers/rookout_controller.go
@@ -22,8 +22,9 @@ import (
 
 type RookoutReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log                logr.Logger
+	Scheme             *runtime.Scheme
+	patchedDeployments []apps.Deployment
 }
 
 type OperatorConfiguration struct {
@@ -65,6 +66,9 @@ func (r *RookoutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 
 			r.updateOperatorConfiguration(operatorConfiguration)
+			for _, v := range r.patchedDeployments {
+				logrus.Infof("Currently patched deployment %v", v.Name)
+			}
 		}
 
 	case DeploymentResource:
@@ -218,6 +222,7 @@ func (r *RookoutReconciler) patchDeployment(ctx context.Context, deployment *app
 		return err
 	}
 
+	r.patchedDeployments = append(r.patchedDeployments, *deployment)
 	logrus.Infof("Deployment %s patched successfully", deployment.Name)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -79,9 +79,10 @@ func main() {
 	}
 
 	if err = (&controllers.RookoutReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Rookout"),
-		Scheme: mgr.GetScheme(),
+		Client:             mgr.GetClient(),
+		Log:                ctrl.Log.WithName("controllers").WithName("Rookout"),
+		Scheme:             mgr.GetScheme(),
+		DeploymentsManager: controllers.NewDeploymentsManager(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Rookout")
 		os.Exit(1)


### PR DESCRIPTION
Fixing the following issues:

1. Saving a state of the running deployments in the operator so on `helm upgrade` we will run the patching mechanism on all deployments in the cluster
2. Remove java SDK from deployments which were patched and then didn't match the new config
3. appended to JAVA_TOOL_OPTIONS env var if it is already populated 