### PR TITLE
RK-11823 - Initial commit for UBI images for RH certification

### DIFF
--- a/.jenkins/buildDocker.sh
+++ b/.jenkins/buildDocker.sh
@@ -5,5 +5,5 @@ echo "Building Operator Init Container Docker..."
 make build_init_container INNER_VERSION=${NEW_VERSION}
 
 echo "Building Operator Docker..."
-make docker-build IMG=us.gcr.io/rookout/rookout-k8s-operator:${NEW_VERSION}
-make docker-build IMG=us.gcr.io/rookout/rookout-k8s-operator-ubi:${NEW_VERSION}
+make docker-build IMG=us.gcr.io/rookout/rookout-k8s-operator:${NEW_VERSION} DOCKERFILE=Dockerfile
+make docker-build IMG=us.gcr.io/rookout/rookout-k8s-operator-ubi:${NEW_VERSION} DOCKERFILE=Dockerfile.ubi

--- a/.jenkins/buildDocker.sh
+++ b/.jenkins/buildDocker.sh
@@ -6,3 +6,4 @@ make build_init_container INNER_VERSION=${NEW_VERSION}
 
 echo "Building Operator Docker..."
 make docker-build IMG=us.gcr.io/rookout/rookout-k8s-operator:${NEW_VERSION}
+make docker-build IMG=us.gcr.io/rookout/rookout-k8s-operator-ubi:${NEW_VERSION}

--- a/.jenkins/pushDocker.sh
+++ b/.jenkins/pushDocker.sh
@@ -8,3 +8,4 @@ make push_init_container INNER_VERSION=${NEW_VERSION}
 
 echo "Pushing Operator Docker..."
 make docker-push IMG=us.gcr.io/rookout/rookout-k8s-operator:${NEW_VERSION}
+make docker-push IMG=us.gcr.io/rookout/rookout-k8s-operator-ubi:${NEW_VERSION}

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,0 +1,31 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-2 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.access.redhat.com/ubi8-micro:8.5-596
+WORKDIR /
+COPY --from=builder /workspace/manager .
+
+# rook dynamic loader
+COPY ./rook.jar /var/rookout/rook.jar
+
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -17,8 +17,6 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8-micro:8.5-596
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,6 +1,7 @@
 # Build the manager binary
 FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-2 as builder
 
+RUN mkdir /workspace
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -tags=ubi -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8-micro:8.5-596
 WORKDIR /

--- a/InitContainer.Dockerfile.ubi
+++ b/InitContainer.Dockerfile.ubi
@@ -1,0 +1,4 @@
+FROM registry.access.redhat.com/ubi8-minimal:8.5-230
+RUN microdnf install curl
+RUN curl -L "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=LATEST" -o rook.jar
+CMD ["cp", "rook.jar", "/rookout/rook.jar"]

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 build-and-deploy:
-	make docker-build docker-push IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0
+	make docker-build docker-push IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0	
 	kubectl delete deployment.apps/rookout-controller-manager -n rookout #Comment this out if this is the first time running on the cluster
 	make install
 	make deploy IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0
@@ -134,14 +134,17 @@ build-and-deploy:
 
 deployment_yamls:
 	make deploy_yaml IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0
+		
 log:
 	kubectl logs deployment.apps/rookout-controller-manager -n rookout -c manager -f
 
 build_init_container:
 	docker build -f InitContainer.Dockerfile . -t us.gcr.io/rookout/rookout-k8s-operator-init-container:${INNER_VERSION}
+	docker build -f InitContainer.Dockerfile.ubi . -t us.gcr.io/rookout/rookout-k8s-operator-init-container-ubi:${INNER_VERSION}
 
 push_init_container:
 	docker push us.gcr.io/rookout/rookout-k8s-operator-init-container:${INNER_VERSION}
+	docker push us.gcr.io/rookout/rookout-k8s-operator-init-container-ubi:${INNER_VERSION}
 
 apply_config:
 	kubectl apply -f ./config/samples/rookout_v1alpha1_rookout.yaml
@@ -151,17 +154,27 @@ publish-operator:
 
 	# Pulling image from rookout's bucket
 	gcloud docker -- pull us.gcr.io/rookout/rookout-k8s-operator:${INNER_VERSION}
+	gcloud docker -- pull us.gcr.io/rookout/rookout-k8s-operator-ubi:${INNER_VERSION}
 	gcloud docker -- pull us.gcr.io/rookout/rookout-k8s-operator-init-container:${INNER_VERSION}
+	gcloud docker -- pull us.gcr.io/rookout/rookout-k8s-operator-init-container-ubi:${INNER_VERSION}
 
 	# Tagging image with dockerhub name and right version
 	docker tag us.gcr.io/rookout/rookout-k8s-operator:${INNER_VERSION} rookout/k8s-operator:${VERSION_TO_PUBLISH}
+	docker tag us.gcr.io/rookout/rookout-k8s-operator-ubi:${INNER_VERSION} rookout/k8s-operator-ubi:${VERSION_TO_PUBLISH}
 	docker tag us.gcr.io/rookout/rookout-k8s-operator:${INNER_VERSION} rookout/k8s-operator:latest
+	docker tag us.gcr.io/rookout/rookout-k8s-operator-ubi:${INNER_VERSION} rookout/k8s-operator-ubi:latest
 	docker tag us.gcr.io/rookout/rookout-k8s-operator-init-container:${INNER_VERSION} rookout/k8s-operator-init-container:${VERSION_TO_PUBLISH}
+	docker tag us.gcr.io/rookout/rookout-k8s-operator-init-container-ubi:${INNER_VERSION} rookout/k8s-operator-init-container-ubi:${VERSION_TO_PUBLISH}
 	docker tag us.gcr.io/rookout/rookout-k8s-operator-init-container:${INNER_VERSION} rookout/k8s-operator-init-container:latest
+	docker tag us.gcr.io/rookout/rookout-k8s-operator-init-container-ubi:${INNER_VERSION} rookout/k8s-operator-init-container-ubi:latest
 
 	# Logging into dockerhub and pushing
 	docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
 	docker push rookout/k8s-operator:${VERSION_TO_PUBLISH}
+	docker push rookout/k8s-operator-ubi:${VERSION_TO_PUBLISH}
 	docker push rookout/k8s-operator:latest
+	docker push rookout/k8s-operator-ubi:latest
 	docker push rookout/k8s-operator-init-container:${VERSION_TO_PUBLISH}
+	docker push rookout/k8s-operator-init-container-ubi:${VERSION_TO_PUBLISH}
 	docker push rookout/k8s-operator-init-container:latest
+	docker push rookout/k8s-operator-init-container-ubi:latest

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build:
-	docker build -t ${IMG} .
+	docker build -t ${IMG} -f ${DOCKERFILE} . 
 
 # Push the docker image
 docker-push:
@@ -126,7 +126,7 @@ bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 build-and-deploy:
-	make docker-build docker-push IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0	
+	make docker-build docker-push IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0 DOCKERFILE=Dockerfile
 	kubectl delete deployment.apps/rookout-controller-manager -n rookout #Comment this out if this is the first time running on the cluster
 	make install
 	make deploy IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0
@@ -134,7 +134,7 @@ build-and-deploy:
 
 deployment_yamls:
 	make deploy_yaml IMG=us.gcr.io/rookout/rookout-k8s-operator:1.0
-		
+
 log:
 	kubectl logs deployment.apps/rookout-controller-manager -n rookout -c manager -f
 

--- a/PROJECT
+++ b/PROJECT
@@ -3,11 +3,19 @@ layout: go.kubebuilder.io/v3
 projectName: rookout-k8s-operator
 repo: github.com/rookout/rookout-k8s-operator
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  domain: rookout.com
   group: rookout
   kind: Rookout
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/rookout/rookout-k8s-operator/api/v1alpha1
   version: v1alpha1
-version: 3-alpha
+version: "3"
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,0 +1,27 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- bases/rookout-k8s-operator.clusterserviceversion.yaml
+- ../default
+- ../samples
+- ../scorecard
+
+# [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
+# Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
+# These patches remove the unnecessary "cert" volume and its manager container volumeMount.
+#patchesJson6902:
+#- target:
+#    group: apps
+#    version: v1
+#    kind: Deployment
+#    name: controller-manager
+#    namespace: system
+#  patch: |-
+#    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/containers/1/volumeMounts/0
+#    # Remove the "cert" volume, since OLM will create and mount a set of certs.
+#    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+#    - op: remove
+#      path: /spec/template/spec/volumes/0

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -1,0 +1,8 @@
+//go:build !ubi
+// +build !ubi
+
+package controllers
+
+const (
+	DefaultInitContainerImage = "docker.io/rookout/k8s-operator-init-container:latest"
+)

--- a/controllers/config_ubi.go
+++ b/controllers/config_ubi.go
@@ -1,0 +1,8 @@
+//go:build ubi
+// +build ubi
+
+package controllers
+
+const (
+	DefaultInitContainerImage = "docker.io/rookout/k8s-operator-init-container-ubi:latest"
+)

--- a/controllers/rookout_controller.go
+++ b/controllers/rookout_controller.go
@@ -23,7 +23,6 @@ import (
 const (
 	DefaultRequeueAfter                 = 10 * time.Second
 	DefaultInitContainerName            = "agent-init-container"
-	DefaultInitContainerImage           = "docker.io/rookout/k8s-operator-init-container:latest"
 	DefaultInitContainerImagePullPolicy = core.PullAlways
 	DefaultSharedVolumeName             = "rookout-agent-shared-volume"
 	DefaultSharedVolumeMountPath        = "/rookout"


### PR DESCRIPTION
Updates -
**new file:   Dockerfile.ubi** - Updated with UBI image required for RH cert
**new file:   InitContainer.Dockerfile.ubi** - Updated with UBI image required for RH cert

**modified:   PROJECT** - config-3alpha no longer supported
```
_WARN[0000] Config version 3-alpha has been stabilized as 3, and 3-alpha is no longer supported. Run `operator-sdk alpha config-3alpha-to-3` to upgrade your PROJECT config file to version 3 
Error: error reading configuration: unable to load the configuration: unable to create config for version "3-alpha": version 3-alpha is not supported_
```

Ran: 'operator-sdk alpha config-3alpha-to-3' to update
`_Your PROJECT config file has been converted from version 3-alpha to 3. Please make sure all config data is correct._`

**new file:   config/manifests/kustomization.yaml** - running 'make bundle' initially gives:
```
_/Users/jhendrick/rookout/workspace/operator/rookout-k8s-operator/bin/kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version 0.0.1  
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/Users/jhendrick/rookout/workspace/operator/rookout-k8s-operator/config/manifests'
FATA[0000] Error generating bundle manifests: could not find manager deployment, should have label control-plane=controller-manager_ 
```

This file is required to be able to successfully run the 'make bundle' command
