### PR TITLE
updating rbac proxy to a certified version and using the pinned digest

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -360,7 +360,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:f000432f07cd187469f0310e3ed9dcf9a5db2be14b8bab9c5293dd1ee8518176
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
- Switching to the certified version of the RBAC Proxy and using the pinned digest, since all images in the CSV require pinned digest as part of the certification process.

Signed-off-by: Adam D. Cornett <adc@redhat.com>