### PR TITLE
RK-12046 - Ubi updates

### DIFF
--- a/InitContainer.Dockerfile.ubi
+++ b/InitContainer.Dockerfile.ubi
@@ -1,4 +1,16 @@
 FROM registry.access.redhat.com/ubi8-minimal:8.5-230
+
+### Required OpenShift Labels
+LABEL name="Rookout Operator Init Container" \
+      vendor="Rookout" \
+      version="v1.0" \
+      release="1" \
+      summary="Rookout Operator for Openshift" \
+      description="This operator will dynamically instrument running services with the Rookout agent"
+
+# Required for OpenShift
+COPY licenses/ /licenses
+
 RUN microdnf install curl
 RUN curl -L "https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.rookout&a=rook&v=LATEST" -o rook.jar
 CMD ["cp", "rook.jar", "/rookout/rook.jar"]

--- a/InitContainer.Dockerfile.ubi
+++ b/InitContainer.Dockerfile.ubi
@@ -1,5 +1,10 @@
 FROM registry.access.redhat.com/ubi8-minimal:8.5-230
 
+RUN microdnf install yum \    
+  && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
+  && yum clean all \
+  && microdnf clean all
+
 ### Required OpenShift Labels
 LABEL name="Rookout Operator Init Container" \
       vendor="Rookout" \


### PR DESCRIPTION
Failed Red Hat vulnerability scan so adding this:

Red Hat components in the container image cannot contain any critical or important vulnerabilities, as defined in our [documentation.](https://access.redhat.com/security/updates/classification)

Why?

These vulnerabilities introduce security risk to our mutual customers.

How?

The certification report will indicate if such vulnerabilities are present in the image. It is recommended to use the most recent version of a layer or package, and to update image content using the following command:

yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical
If using ubi-minimal, add this multi-line command instead:

RUN microdnf install yum \
              
  && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
              
  && yum clean all \
              
  && microdnf clean all